### PR TITLE
Undefined name: totp --> timed_otp

### DIFF
--- a/ai-trading-system/src/application/clients/robinhood_client.py
+++ b/ai-trading-system/src/application/clients/robinhood_client.py
@@ -13,7 +13,7 @@ class RobinHoodClient:
 
     def trade_robinhood(last_real_data, forecast):
         timed_otp = pyotp.TOTP(self._rh_mfa_code).now()
-        login = rh.login(self._rh_user_email, self._rh_password, mfa_code=totp)
+        login = rh.login(self._rh_user_email, self._rh_password, mfa_code=timed_otp)
 
         last_real_data, forecast = get_forecast()
 

--- a/original_boilerplate/handler.py
+++ b/original_boilerplate/handler.py
@@ -54,7 +54,7 @@ def get_forecast():
 
 def trade_robinhood():
     timed_otp = pyotp.TOTP(RH_MFA_CODE).now()
-    login = rh.login(RH_USER_EMAIL, RH_PASSWORD, mfa_code=totp)
+    login = rh.login(RH_USER_EMAIL, RH_PASSWORD, mfa_code=timed_otp)
 
     last_real_data, forecast = get_forecast()
 


### PR DESCRIPTION
`totp` is an _undefined name_ in this context (#3) which will raise NameError at runtime while `timed_otp` is defined on the previous line.